### PR TITLE
added support for sim output with multiple sims

### DIFF
--- a/cmd/cyan/main.go
+++ b/cmd/cyan/main.go
@@ -31,6 +31,7 @@ var (
 )
 
 var simid []byte
+var simids [][]byte
 
 var command string
 
@@ -92,7 +93,8 @@ func initdb() {
 	if *simidstr == "" {
 		ids, err := query.SimIds(db)
 		fatalif(err)
-		simid = ids[0]
+		simids = ids
+	        simid = simids[0]
 	} else {
 		simid = uuid.Parse(*simidstr)
 		if simid == nil {
@@ -227,8 +229,11 @@ JOIN DecayMode AS d ON i.SimId=d.SimId
 WHERE i.SimId = ?
 `
 	customSql[cmd] = s
-	buf := doCustom(cmd, simid)
-	fmt.Print(buf.String())
+	var buf string
+	for _, sid := range simids {
+	        buf += doCustom(cmd, sid).String()
+	}
+	fmt.Print(buf)
 }
 
 func doPost(cmd string, args []string) {


### PR DESCRIPTION
not perfect, but starts to address #5

before this patch:

```
$ cyan -db ~/work/publications/dre/scenarios/cyclus.sqlite sims
SimId                                Duration Handle      Decay  
fdf043b6-b0c9-4055-8773-6bb9cfaf0ace 600      dre_recycle manual 
```

after:

```
$ ./cyan -db ~/work/publications/dre/scenarios/cyclus.sqlite sims
SimId                                Duration Handle      Decay  
fdf043b6-b0c9-4055-8773-6bb9cfaf0ace 600      dre_recycle manual 
SimId                                Duration Handle   Decay  
bbda8c4f-8156-4ceb-9fd5-6fbfad05184c 600      dre_base manual
```

this uses the basic `doCustom()` plumbing thus repeats the headers. it could be cleaned up to not repeat headers and get better spacing. or a better sql command could be used to loop over all simids in `doSims()`. probably the second is a better choice, but my go + sql-foo is nonexistant + rusty. 
